### PR TITLE
Fix category refresh and product dropdown

### DIFF
--- a/app/components/products/product-table.tsx
+++ b/app/components/products/product-table.tsx
@@ -10,7 +10,8 @@ import {
   type ColumnFiltersState,
   getFilteredRowModel,
 } from "@tanstack/react-table"
-import { Edit, Link, MoreHorizontal, Star, Trash } from "lucide-react"
+import { Edit, MoreHorizontal, Star, Trash } from "lucide-react"
+import { Link } from "@remix-run/react"
 
 import { Button } from "~/components/ui/button"
 import {


### PR DESCRIPTION
## Summary
- ensure product dropdown uses Remix Link instead of an icon
- navigate after category edits only after server confirms success

## Testing
- `npm run lint` *(fails: invalid option)*
- `npm run typecheck` *(fails: cannot find type definition files)*