### PR TITLE
Normalize loader types for products

### DIFF
--- a/app/routes/products.$id.tsx
+++ b/app/routes/products.$id.tsx
@@ -78,14 +78,30 @@ export async function loader({ params }: { params: { id: string } }) {
 
   const selectedCategoryIds = productCategoriesData.map((pc) => pc.categoryId)
 
+  const normalizedProduct = {
+    ...product,
+    overallRating: product.overallRating ? Number(product.overallRating) : null,
+    dateFirstAvailable: product.dateFirstAvailable
+      ? new Date(product.dateFirstAvailable)
+      : null,
+  }
+
+  const normalizedVariants = variants.map((v) => ({
+    ...v,
+    price: Number(v.price),
+    listPrice: v.listPrice ? Number(v.listPrice) : null,
+    shippingWeightKg: v.shippingWeightKg ? Number(v.shippingWeightKg) : null,
+    bestByDate: v.bestByDate ? new Date(v.bestByDate) : null,
+  }))
+
   return {
-    product,
+    product: normalizedProduct,
     selectedCategoryIds,
     brandsData,
     categoriesData,
     nutritionFacts: nutritionFactsData,
     productImages: images,
-    productVariants: variants,
+    productVariants: normalizedVariants,
   }
 
 }


### PR DESCRIPTION
## Summary
- normalize loader values in `products.$id` route so they match the types in `ProductForm`

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for '@remix-run/node')*
- `npm run lint` *(fails: Invalid option '--ignore-path')*