### PR TITLE
Add basic orders page

### DIFF
--- a/app/action/order.ts
+++ b/app/action/order.ts
@@ -1,0 +1,33 @@
+export interface Order {
+  orderId: number;
+  customerName: string;
+  totalAmount: number;
+  currency: string;
+  paymentVerified: boolean;
+  status: string;
+  orderedAt: Date;
+}
+
+export async function getOrders(): Promise<Order[]> {
+  // TODO: replace with real database call
+  return [
+    {
+      orderId: 1,
+      customerName: "John Doe",
+      totalAmount: 49.99,
+      currency: "USD",
+      paymentVerified: false,
+      status: "Pending",
+      orderedAt: new Date(),
+    },
+    {
+      orderId: 2,
+      customerName: "Jane Smith",
+      totalAmount: 79.5,
+      currency: "USD",
+      paymentVerified: true,
+      status: "Completed",
+      orderedAt: new Date(),
+    },
+  ];
+}

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from '@remix-run/react';
 import { cn } from '~/libs/utils';
-import { BarChart3, Box, Grid3X3, Home, Package, Star, Tag } from 'lucide-react';
+import { BarChart3, Box, Grid3X3, Home, Package, Star, Tag, ShoppingCart } from 'lucide-react';
 
 const routes = [
   {
@@ -22,6 +22,11 @@ const routes = [
     label: "Products",
     icon: Package,
     href: "/products",
+  },
+  {
+    label: "Orders",
+    icon: ShoppingCart,
+    href: "/orders",
   },
   // {
   //   label: "Product Variants",

--- a/app/components/orders/order-table.tsx
+++ b/app/components/orders/order-table.tsx
@@ -1,0 +1,205 @@
+import { useState } from "react";
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+  type SortingState,
+  getSortedRowModel,
+  type ColumnFiltersState,
+  getFilteredRowModel,
+} from "@tanstack/react-table";
+import { Check, MoreHorizontal, X } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+import { Input } from "~/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { Badge } from "~/components/ui/badge";
+import { toast } from "sonner";
+
+export interface Order {
+  orderId: number;
+  customerName: string;
+  totalAmount: number;
+  currency: string;
+  paymentVerified: boolean;
+  status: string;
+  orderedAt: Date | string;
+}
+
+export function OrdersTable({ data }: { data: Order[] }) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const columns: ColumnDef<Order>[] = [
+    {
+      accessorKey: "orderId",
+      header: "ID",
+      cell: ({ row }) => <div className="w-[80px]">{row.getValue("orderId")}</div>,
+    },
+    {
+      accessorKey: "customerName",
+      header: "Customer",
+      cell: ({ row }) => <div className="font-medium">{row.getValue("customerName")}</div>,
+    },
+    {
+      accessorKey: "totalAmount",
+      header: "Amount",
+      cell: ({ row }) => {
+        const amount = Number.parseFloat(row.getValue("totalAmount"));
+        const currency = row.getValue("currency") as string;
+        return (
+          <div className="font-medium">
+            {currency} {amount.toFixed(2)}
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "paymentVerified",
+      header: "Payment",
+      cell: ({ row }) => {
+        const verified = row.getValue("paymentVerified") as boolean;
+        return verified ? (
+          <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+            Verified
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="bg-red-50 text-red-700 border-red-200">
+            Pending
+          </Badge>
+        );
+      },
+    },
+    {
+      accessorKey: "status",
+      header: "Status",
+      cell: ({ row }) => <div>{row.getValue("status")}</div>,
+    },
+    {
+      accessorKey: "orderedAt",
+      header: "Ordered At",
+      cell: ({ row }) => {
+        const date = row.getValue("orderedAt") as Date | string;
+        return <div>{new Date(date).toLocaleDateString()}</div>;
+      },
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => {
+        const order = row.original;
+        return (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="h-8 w-8 p-0">
+                <span className="sr-only">Open menu</span>
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuLabel>Actions</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {!order.paymentVerified && (
+                <DropdownMenuItem
+                  onClick={() => {
+                    toast("Payment verified");
+                  }}
+                >
+                  <Check className="mr-2 h-4 w-4" />
+                  Verify Payment
+                </DropdownMenuItem>
+              )}
+              {order.status !== "Cancelled" && (
+                <DropdownMenuItem
+                  onClick={() => {
+                    toast("Order cancelled");
+                  }}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <X className="mr-2 h-4 w-4" />
+                  Cancel Order
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        );
+      },
+    },
+  ];
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    onColumnFiltersChange: setColumnFilters,
+    getFilteredRowModel: getFilteredRowModel(),
+    state: {
+      sorting,
+      columnFilters,
+    },
+  });
+
+  return (
+    <div>
+      <div className="flex items-center py-4">
+        <Input
+          placeholder="Filter orders..."
+          value={(table.getColumn("customerName")?.getFilterValue() as string) ?? ""}
+          onChange={(event) => table.getColumn("customerName")?.setFilterValue(event.target.value)}
+          className="max-w-sm"
+        />
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No orders found.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Button variant="outline" size="sm" onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+          Previous
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/orders._index.tsx
+++ b/app/routes/orders._index.tsx
@@ -1,0 +1,28 @@
+import { useLoaderData } from "@remix-run/react";
+import MainLayout from "~/layouts/MainLayout";
+import { getOrders } from "~/action/order";
+import { OrdersTable } from "~/components/orders/order-table";
+
+export default function OrdersPage() {
+  const { orderList } = useLoaderData<typeof loader>();
+
+  return (
+    <MainLayout>
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Orders</h1>
+            <p className="text-muted-foreground">Manage customer orders</p>
+          </div>
+        </div>
+
+        <OrdersTable data={orderList} />
+      </div>
+    </MainLayout>
+  );
+}
+
+export async function loader() {
+  const orderList = await getOrders();
+  return { orderList };
+}


### PR DESCRIPTION
## Summary
- add static order data loader
- list orders in a table with verify/cancel actions
- link orders page from sidebar navigation

## Testing
- `npm run lint` *(fails: invalid ESLint options)*
- `npm run typecheck` *(fails: cannot find type definitions)*