### PR TITLE
Add CMS config page and API

### DIFF
--- a/app/action/config.ts
+++ b/app/action/config.ts
@@ -1,0 +1,29 @@
+import { configTable } from "../db/schema";
+import { db } from "~/db/db.server";
+import { eq } from "drizzle-orm";
+
+export async function getConfig(key: string) {
+  const result = await db
+    .select()
+    .from(configTable)
+    .where(eq(configTable.key, key))
+    .limit(1);
+  return result[0];
+}
+
+export async function upsertConfig(key: string, value: unknown, userId = "system") {
+  const existing = await getConfig(key);
+  if (existing) {
+    await db
+      .update(configTable)
+      .set({ value, updatedBy: userId, updatedAt: new Date() })
+      .where(eq(configTable.key, key));
+  } else {
+    await db.insert(configTable).values({
+      key,
+      value,
+      createdBy: userId,
+      updatedBy: userId,
+    });
+  }
+}

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from '@remix-run/react';
 import { cn } from '~/libs/utils';
-import { BarChart3, Box, Grid3X3, Home, Package, Star, Tag, ShoppingCart } from 'lucide-react';
+import { BarChart3, Box, Grid3X3, Home, Package, Star, Tag, ShoppingCart, Settings } from 'lucide-react';
 
 const routes = [
   {
@@ -27,6 +27,11 @@ const routes = [
     label: "Orders",
     icon: ShoppingCart,
     href: "/orders",
+  },
+  {
+    label: "CMS",
+    icon: Settings,
+    href: "/configs",
   },
   // {
   //   label: "Product Variants",

--- a/app/routes/api.configs.$key.ts
+++ b/app/routes/api.configs.$key.ts
@@ -1,0 +1,22 @@
+import { json } from "@remix-run/node";
+import type { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
+import { getConfig, upsertConfig } from "~/action/config";
+import { HTTP_STATUS } from "~/config/http";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const key = params.key;
+  if (!key) throw new Response("Config key required", { status: HTTP_STATUS.BAD_REQUEST });
+  const config = await getConfig(key);
+  if (!config) {
+    throw new Response("Not found", { status: HTTP_STATUS.NOT_FOUND });
+  }
+  return json(config);
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const key = params.key;
+  if (!key) throw new Response("Config key required", { status: HTTP_STATUS.BAD_REQUEST });
+  const body = await request.json();
+  await upsertConfig(key, body.value, "admin");
+  return json({ status: HTTP_STATUS.OK });
+}

--- a/app/routes/configs._index.tsx
+++ b/app/routes/configs._index.tsx
@@ -1,0 +1,101 @@
+import { type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData, useActionData, useSubmit } from "@remix-run/react";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import MainLayout from "~/layouts/MainLayout";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "~/components/ui/form";
+import { Card, CardContent } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Button } from "~/components/ui/button";
+import { toast } from "sonner";
+import { getConfig, upsertConfig } from "~/action/config";
+import { HTTP_STATUS } from "~/config/http";
+
+const formSchema = z.object({
+  heroBrandImage: z.string().url("Must be a valid URL"),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export default function ConfigPage() {
+  const { heroBrandImage } = useLoaderData<typeof loader>();
+  const actionData = useActionData<{ status: number }>();
+  const submit = useSubmit();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      heroBrandImage: heroBrandImage || "",
+    },
+  });
+
+  useEffect(() => {
+    if (!actionData) return;
+    if ([HTTP_STATUS.OK, HTTP_STATUS.CREATED].includes(actionData.status)) {
+      toast("Configuration saved.");
+    }
+  }, [actionData]);
+
+  function onSubmit(data: FormValues) {
+    const formData = new FormData();
+    formData.append("data", JSON.stringify(data));
+    submit(formData, { method: "POST" });
+  }
+
+  return (
+    <MainLayout>
+      <div className="flex flex-col gap-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">CMS Configuration</h1>
+          <p className="text-muted-foreground">Update landing page assets</p>
+        </div>
+        <Card>
+          <CardContent className="pt-6">
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                <FormField
+                  control={form.control}
+                  name="heroBrandImage"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Hero Brand Image URL</FormLabel>
+                      <FormControl>
+                        <Input placeholder="https://example.com/image.jpg" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit">Save</Button>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
+      </div>
+    </MainLayout>
+  );
+}
+
+export async function loader({}: LoaderFunctionArgs) {
+  const config = await getConfig("heroBrandImage");
+  return {
+    heroBrandImage: (config?.value as string) || "",
+  };
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const data = formData.get("data");
+  if (!data) {
+    throw new Response("Invalid data", { status: HTTP_STATUS.BAD_REQUEST });
+  }
+  try {
+    const parsed = JSON.parse(data.toString()) as FormValues;
+    await upsertConfig("heroBrandImage", parsed.heroBrandImage, "admin");
+    return { status: HTTP_STATUS.OK };
+  } catch (error) {
+    throw new Response("Invalid JSON", { status: HTTP_STATUS.BAD_REQUEST });
+  }
+}


### PR DESCRIPTION
## Summary
- add actions to get and update configuration values in DB
- create CMS configuration page for hero brand image
- expose API endpoint to fetch/update configs
- add link to CMS in sidebar navigation

## Testing
- `npm run lint` *(fails: Invalid option)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684047c2ce44832689283455b2d60831