### PR TITLE
Add banner image upload

### DIFF
--- a/app/routes/configs._index.tsx
+++ b/app/routes/configs._index.tsx
@@ -2,32 +2,35 @@ import { type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/nod
 import { useLoaderData, useActionData, useSubmit } from "@remix-run/react";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import MainLayout from "~/layouts/MainLayout";
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "~/components/ui/form";
 import { Card, CardContent } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Button } from "~/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { toast } from "sonner";
 import { getConfig, upsertConfig } from "~/action/config";
 import { HTTP_STATUS } from "~/config/http";
+import { fileUpload } from "~/libs/file-upload";
 
 const formSchema = z.object({
-  heroBrandImage: z.string().url("Must be a valid URL"),
+  image: z.string().url("Must be a valid URL"),
 });
 
 type FormValues = z.infer<typeof formSchema>;
 
 export default function ConfigPage() {
-  const { heroBrandImage } = useLoaderData<typeof loader>();
+  const { banner } = useLoaderData<typeof loader>();
   const actionData = useActionData<{ status: number }>();
   const submit = useSubmit();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      heroBrandImage: heroBrandImage || "",
+      image: banner.image || "",
     },
   });
 
@@ -44,6 +47,13 @@ export default function ConfigPage() {
     submit(formData, { method: "POST" });
   }
 
+  async function handleUpload() {
+    const file = fileInputRef.current?.files?.[0];
+    if (!file) return;
+    const result = await fileUpload(file);
+    form.setValue("image", result.file.url);
+  }
+
   return (
     <MainLayout>
       <div className="flex flex-col gap-6">
@@ -53,24 +63,36 @@ export default function ConfigPage() {
         </div>
         <Card>
           <CardContent className="pt-6">
-            <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                <FormField
-                  control={form.control}
-                  name="heroBrandImage"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Hero Brand Image URL</FormLabel>
-                      <FormControl>
-                        <Input placeholder="https://example.com/image.jpg" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <Button type="submit">Save</Button>
-              </form>
-            </Form>
+            <Tabs defaultValue="banner" className="w-full">
+              <TabsList className="mb-4">
+                <TabsTrigger value="banner">Hero Brand Image</TabsTrigger>
+              </TabsList>
+              <TabsContent value="banner" className="space-y-6">
+                <Form {...form}>
+                  <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                    <FormField
+                      control={form.control}
+                      name="image"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Hero Brand Image</FormLabel>
+                          {field.value && (
+                            <img src={field.value} alt="Hero" className="h-32 mb-2 rounded" />
+                          )}
+                          <FormControl>
+                            <Input type="hidden" {...field} />
+                          </FormControl>
+                          <Input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleUpload} />
+                          <Button type="button" onClick={() => fileInputRef.current?.click()}>Upload Image</Button>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <Button type="submit">Save</Button>
+                  </form>
+                </Form>
+              </TabsContent>
+            </Tabs>
           </CardContent>
         </Card>
       </div>
@@ -79,10 +101,9 @@ export default function ConfigPage() {
 }
 
 export async function loader({}: LoaderFunctionArgs) {
-  const config = await getConfig("heroBrandImage");
-  return {
-    heroBrandImage: (config?.value as string) || "",
-  };
+  const config = await getConfig("banner");
+  const banner = (config?.value as { image: string } | undefined) || { image: "" };
+  return { banner };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -93,7 +114,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
   try {
     const parsed = JSON.parse(data.toString()) as FormValues;
-    await upsertConfig("heroBrandImage", parsed.heroBrandImage, "admin");
+    await upsertConfig("banner", { image: parsed.image }, "admin");
     return { status: HTTP_STATUS.OK };
   } catch (error) {
     throw new Response("Invalid JSON", { status: HTTP_STATUS.BAD_REQUEST });


### PR DESCRIPTION
## Summary
- improve Config page to let admins choose hero brand image via file upload
- store uploaded banner image URL in `configs` table under the `banner` key

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: cannot find type definition file for '@remix-run/node')*

------
https://chatgpt.com/codex/tasks/task_e_68404c6c729883268629548601ee8ed6