### PR TITLE
Improve order detail page UI and show payment slip

### DIFF
--- a/app/action/order.ts
+++ b/app/action/order.ts
@@ -56,6 +56,7 @@ export async function getOrderDetail(id: number) {
       notes: orders.notes,
       customerName: user.name,
       paymentStatus: payments.status,
+      paymentProviderDetails: payments.providerDetails,
     })
     .from(orders)
     .leftJoin(user, eq(orders.userId, user.id))
@@ -78,6 +79,7 @@ export async function getOrderDetail(id: number) {
   return {
     ...order,
     totalAmount: Number(order.totalAmount),
+    paymentProviderDetails: order.paymentProviderDetails as unknown as Record<string, unknown> | null,
     items: items.map((i) => ({
       ...i,
       price: Number(i.price),

--- a/app/routes/orders.$id.tsx
+++ b/app/routes/orders.$id.tsx
@@ -2,30 +2,88 @@ import { useLoaderData } from "@remix-run/react";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { getOrderDetail } from "~/action/order";
 import MainLayout from "~/layouts/MainLayout";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "~/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { Badge } from "~/components/ui/badge";
+import { Separator } from "~/components/ui/separator";
 
 export default function OrderDetailPage() {
   const { order } = useLoaderData<typeof loader>();
+  const slipUrl =
+    (order.paymentProviderDetails as Record<string, unknown> | null)?.slipUrl as
+      | string
+      | undefined;
 
   return (
     <MainLayout>
-      <div className="flex flex-col gap-4">
-        <h1 className="text-3xl font-bold tracking-tight">Order #{order.id}</h1>
-        <p>Status: {order.status}</p>
-        <p>
-          Total: {order.currency} {Number(order.totalAmount).toFixed(2)}
-        </p>
-        <div>
-          <h2 className="font-semibold">Items</h2>
-          <ul className="list-disc pl-6">
-            {order.items.map((item) => (
-              <li key={item.productId}>
-                {item.name} x{item.quantity} - {order.currency}{" "}
-                {item.price.toFixed(2)}
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Order #{order.id}</CardTitle>
+          <CardDescription>Status: {order.status}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <p>
+              Total: {order.currency} {Number(order.totalAmount).toFixed(2)}
+            </p>
+            <p>
+              Payment:{" "}
+              {order.paymentStatus === "successful" ? (
+                <Badge className="bg-green-50 text-green-700 border-green-200" variant="outline">
+                  Verified
+                </Badge>
+              ) : (
+                <Badge className="bg-red-50 text-red-700 border-red-200" variant="outline">
+                  Pending
+                </Badge>
+              )}
+            </p>
+          </div>
+
+          {slipUrl && (
+            <div className="space-y-2">
+              <p className="font-semibold">Payment Slip</p>
+              <img
+                src={slipUrl}
+                alt="Payment Slip"
+                className="max-w-xs rounded-md border"
+              />
+            </div>
+          )}
+
+          <Separator />
+
+          <div className="space-y-2">
+            <h2 className="font-semibold">Items</h2>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Product</TableHead>
+                  <TableHead>Qty</TableHead>
+                  <TableHead className="text-right">Price</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {order.items.map((item) => (
+                  <TableRow key={item.productId}>
+                    <TableCell>{item.name}</TableCell>
+                    <TableCell>{item.quantity}</TableCell>
+                    <TableCell className="text-right">
+                      {order.currency} {item.price.toFixed(2)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
     </MainLayout>
   );
 }


### PR DESCRIPTION
## Summary
- load payment provider details in order data
- redesign order detail page with card layout
- display payment slip image when available

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_684096423fc4832690af061490033399