### PR TITLE
Add order status management

### DIFF
--- a/app/action/order.ts
+++ b/app/action/order.ts
@@ -5,6 +5,8 @@ import {
   user,
   orderItems,
   products,
+  orderStatusEnum,
+  paymentStatusEnum,
 } from "~/db/schema";
 import { eq } from "drizzle-orm";
 
@@ -17,6 +19,27 @@ export interface Order {
   status: string;
   orderedAt: Date;
 }
+
+export const ORDER_STATUSES = [
+  "pending",
+  "processing",
+  "shipped",
+  "delivered",
+  "cancelled",
+  "refunded",
+  "failed",
+] as const;
+
+export type OrderStatus = (typeof ORDER_STATUSES)[number];
+
+export const PAYMENT_STATUSES = [
+  "pending",
+  "successful",
+  "failed",
+  "refunded",
+] as const;
+
+export type PaymentStatus = (typeof PAYMENT_STATUSES)[number];
 
 export async function getOrders(): Promise<Order[]> {
   const rows = await db
@@ -104,4 +127,18 @@ export async function cancelOrder(orderId: number) {
     .update(orders)
     .set({ status: "cancelled" })
     .where(eq(orders.id, orderId));
+}
+
+export async function updateOrderStatus(orderId: number, status: OrderStatus) {
+  await db.update(orders).set({ status }).where(eq(orders.id, orderId));
+}
+
+export async function updatePaymentStatus(
+  orderId: number,
+  status: PaymentStatus,
+) {
+  await db
+    .update(payments)
+    .set({ status })
+    .where(eq(payments.orderId, orderId));
 }

--- a/app/routes/orders.$id.tsx
+++ b/app/routes/orders.$id.tsx
@@ -1,6 +1,13 @@
-import { useLoaderData } from "@remix-run/react";
-import type { LoaderFunctionArgs } from "@remix-run/node";
-import { getOrderDetail } from "~/action/order";
+import { useLoaderData, useSubmit } from "@remix-run/react";
+import type { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
+import {
+  getOrderDetail,
+  verifyPayment,
+  updateOrderStatus,
+  updatePaymentStatus,
+  ORDER_STATUSES,
+} from "~/action/order";
+import { HTTP_STATUS } from "~/config/http";
 import MainLayout from "~/layouts/MainLayout";
 import {
   Card,
@@ -12,26 +19,69 @@ import {
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
 import { Badge } from "~/components/ui/badge";
 import { Separator } from "~/components/ui/separator";
+import { Button } from "~/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
 
 
 export default function OrderDetailPage() {
   const { order } = useLoaderData<typeof loader>();
-  const slipUrl = order.paymentSlip
+  const submit = useSubmit();
+  const slipUrl = order.paymentSlip;
+
+  function handleVerify() {
+    const formData = new FormData();
+    formData.append("intent", "verify-payment");
+    submit(formData, { method: "POST" });
+  }
+
+  function handleStatusChange(value: string) {
+    const formData = new FormData();
+    formData.append("intent", "update-status");
+    formData.append("status", value);
+    submit(formData, { method: "PUT" });
+  }
+
+  function handlePaymentStatusChange(value: string) {
+    const formData = new FormData();
+    formData.append("intent", "update-payment");
+    formData.append("status", value);
+    submit(formData, { method: "PUT" });
+  }
 
   return (
     <MainLayout>
       <Card>
         <CardHeader>
           <CardTitle>Order #{order.id}</CardTitle>
-          <CardDescription>Status: {order.status}</CardDescription>
+          <div className="mt-2 flex items-center gap-2">
+            <CardDescription>Status:</CardDescription>
+            <Select defaultValue={order.status} onValueChange={handleStatusChange}>
+              <SelectTrigger className="w-[150px]">
+                <SelectValue placeholder="Select status" />
+              </SelectTrigger>
+              <SelectContent>
+                {ORDER_STATUSES.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="space-y-2">
             <p>
               Total: {order.currency} {Number(order.totalAmount).toFixed(2)}
             </p>
-            <p>
-              Payment:{" "}
+            <p className="flex items-center gap-2">
+              <span>Payment:</span>
               {order.paymentStatus === "successful" ? (
                 <Badge className="bg-green-50 text-green-700 border-green-200" variant="outline">
                   Verified
@@ -41,7 +91,28 @@ export default function OrderDetailPage() {
                   Pending
                 </Badge>
               )}
+              {order.status === "pending" && order.paymentStatus !== "successful" && (
+                <Button variant="outline" size="sm" onClick={handleVerify}>
+                  Verify
+                </Button>
+              )}
             </p>
+            {order.status !== "pending" && order.status !== "processing" && (
+              <div className="mt-2">
+                <Select
+                  defaultValue={order.paymentStatus}
+                  onValueChange={handlePaymentStatusChange}
+                >
+                  <SelectTrigger className="w-[150px]">
+                    <SelectValue placeholder="Payment status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="pending">pending</SelectItem>
+                    <SelectItem value="refunded">refunded</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
           </div>
 
           {slipUrl && (
@@ -96,4 +167,39 @@ export async function loader({ params }: LoaderFunctionArgs) {
     throw new Response("Order not found", { status: 404 });
   }
   return { order };
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const orderId = Number.parseInt(params.id || "");
+  if (Number.isNaN(orderId)) {
+    throw new Response("Invalid order ID", { status: 400 });
+  }
+
+  const formData = await request.formData();
+  const intent = formData.get("intent");
+
+  if (intent === "verify-payment") {
+    await verifyPayment(orderId);
+    return { status: HTTP_STATUS.OK };
+  }
+
+  if (intent === "update-status") {
+    const status = formData.get("status")?.toString();
+    if (!status) {
+      throw new Response("Status required", { status: HTTP_STATUS.BAD_REQUEST });
+    }
+    await updateOrderStatus(orderId, status as (typeof ORDER_STATUSES)[number]);
+    return { status: HTTP_STATUS.OK };
+  }
+
+  if (intent === "update-payment") {
+    const status = formData.get("status")?.toString();
+    if (!status) {
+      throw new Response("Status required", { status: HTTP_STATUS.BAD_REQUEST });
+    }
+    await updatePaymentStatus(orderId, status as any);
+    return { status: HTTP_STATUS.OK };
+  }
+
+  return new Response("Bad Request", { status: HTTP_STATUS.BAD_REQUEST });
 }


### PR DESCRIPTION
## Summary
- allow admins to update order and payment status
- show verify button for pending orders
- offer dropdowns for managing statuses

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6840ace5b5348326adb555be84eba8dc